### PR TITLE
'Cancel' for PromiseKit

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,5 @@
-github "mxcl/PromiseKit" ~> 6.3
+#github "mxcl/PromiseKit" ~> 6.3
+github "dougzilla32/PromiseKit" "CoreCancel"
 github "mxcl/OMGHTTPURLRQ" ~> 3.2
-github "PromiseKit/Foundation" ~> 3.1
+#github "PromiseKit/Foundation" ~> 3.1
+github "dougzilla32/Foundation" "CoreCancel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "cb9088a9f486edb4c40751f63c21fcf077fb54f1"
-github "dougzilla32/PromiseKit" "1e5519010c2b519f03a306f023accc93b46e2bf3"
+github "dougzilla32/Foundation" "fd1d66c24d9ac6b6878603e16356d8c9cac46dc8"
+github "dougzilla32/PromiseKit" "5069bdc1b10847d47f5fdbe3accb623b3b1908a3"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "PromiseKit/Foundation" "3.1.0"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"
-github "mxcl/PromiseKit" "6.3.3"
+github "mxcl/PromiseKit" "6.3.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "PromiseKit/Foundation" "3.1.0"
+github "dougzilla32/Foundation" "7fdbd977b1f7137a19bd5847081336c413f81b68"
+github "dougzilla32/PromiseKit" "e858d54f6bcb83a435c3ec8016c9a6c2f6befeb2"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"
 github "mxcl/PromiseKit" "6.3.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "7fdbd977b1f7137a19bd5847081336c413f81b68"
-github "dougzilla32/PromiseKit" "e858d54f6bcb83a435c3ec8016c9a6c2f6befeb2"
+github "dougzilla32/Foundation" "cb9088a9f486edb4c40751f63c21fcf077fb54f1"
+github "dougzilla32/PromiseKit" "1e5519010c2b519f03a306f023accc93b46e2bf3"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"
-github "mxcl/PromiseKit" "6.3.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "87699e7591b16f78410ccebe7464f41daf98fbf3"
-github "dougzilla32/PromiseKit" "d1299007c75f7f31ebeccd9a317f2c46fdeb04f3"
+github "dougzilla32/Foundation" "4b6d86210cf2f3a2010d37c44d7d63ccb20547b1"
+github "dougzilla32/PromiseKit" "288f7fbabc0b33c558bf908a3a0770693223d4e0"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "fd1d66c24d9ac6b6878603e16356d8c9cac46dc8"
-github "dougzilla32/PromiseKit" "5069bdc1b10847d47f5fdbe3accb623b3b1908a3"
+github "dougzilla32/Foundation" "194f0512d91ff311223d094fdbe80d04d1a57af9"
+github "dougzilla32/PromiseKit" "dcf77e0afe55e3d18da9a2a5bda28cdf1adcb5a9"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "26c196c1a3cc85bf38802ab86a6477d649ef21ad"
-github "dougzilla32/PromiseKit" "3be75b2bfd08e32c118ad9dc9c7837111712e03a"
+github "dougzilla32/Foundation" "87699e7591b16f78410ccebe7464f41daf98fbf3"
+github "dougzilla32/PromiseKit" "d1299007c75f7f31ebeccd9a317f2c46fdeb04f3"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "194f0512d91ff311223d094fdbe80d04d1a57af9"
-github "dougzilla32/PromiseKit" "dcf77e0afe55e3d18da9a2a5bda28cdf1adcb5a9"
+github "dougzilla32/Foundation" "6c9c9d0018d1faf82ceca0b9892b27c37820fbc0"
+github "dougzilla32/PromiseKit" "ff694600d4d03458121515bdc027ba76df14f7ef"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "dougzilla32/Foundation" "6c9c9d0018d1faf82ceca0b9892b27c37820fbc0"
-github "dougzilla32/PromiseKit" "ff694600d4d03458121515bdc027ba76df14f7ef"
+github "dougzilla32/Foundation" "26c196c1a3cc85bf38802ab86a6477d649ef21ad"
+github "dougzilla32/PromiseKit" "3be75b2bfd08e32c118ad9dc9c7837111712e03a"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/Sources/NSURLSession+OMG+Promise.swift
+++ b/Sources/NSURLSession+OMG+Promise.swift
@@ -190,8 +190,8 @@ extension URLSession {
      - Parameter query: The parameters to be encoded as the query string for the GET request.
      - Returns: A cancellable promise that represents the GET request.
      */
-    public func GETCC(_ url: String, query: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.get(url, query) as URLRequest)
+    public func cancellableGET(_ url: String, query: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.get(url, query) as URLRequest)
     }
 
     /**
@@ -212,8 +212,8 @@ extension URLSession {
      - Parameter formData: The parameters to be form URL-encoded and passed as the POST body.
      - Returns: A cancellable promise that represents the POST request.
      */
-    public func POSTCC(_ url: String, formData: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.post(url, formData) as URLRequest)
+    public func cancellablePOST(_ url: String, formData: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.post(url, formData) as URLRequest)
     }
 
     /**
@@ -232,8 +232,8 @@ extension URLSession {
      - Returns: A cancellable promise that represents the POST request.
      - SeeAlso: [https://github.com/mxcl/OMGHTTPURLRQ](OMGHTTPURLRQ)
      */
-    public func POSTCC(_ url: String, multipartFormData: OMGMultipartFormData) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.post(url, multipartFormData) as URLRequest)
+    public func cancellablePOST(_ url: String, multipartFormData: OMGMultipartFormData) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.post(url, multipartFormData) as URLRequest)
     }
 
     /**
@@ -253,8 +253,8 @@ extension URLSession {
      - Parameter json: The parameters to be JSON-encoded and passed as the POST body.
      - Returns: A cancellable promise that represents the POST request.
      */
-    public func POSTCC(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.post(url, json: json) as URLRequest)
+    public func cancellablePOST(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.post(url, json: json) as URLRequest)
     }
 
     /**
@@ -270,8 +270,8 @@ extension URLSession {
      - Parameter json: The parameters to be JSON-encoded and passed as the PUT body.
      - Returns: A cancellable promise that represents the PUT request.
      */
-    public func PUTCC(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.put(url, json: json) as URLRequest)
+    public func cancellablePUT(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.put(url, json: json) as URLRequest)
     }
 
     /**
@@ -286,8 +286,8 @@ extension URLSession {
      - Parameter url: The URL to request.
      - Returns: A cancellable promise that represents the PUT request.
      */
-    public func DELETECC(_ url: String) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.delete(url, nil) as URLRequest)
+    public func cancellableDELETE(_ url: String) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.delete(url, nil) as URLRequest)
     }
 
     /**
@@ -302,11 +302,11 @@ extension URLSession {
      - Parameter json: The JSON parameters to encode as the PATCH body.
      - Returns: A cancellable promise that represents the PUT request.
      */
-    public func PATCHCC(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return startCC(try OMGHTTPURLRQ.patch(url, json: json) as URLRequest)
+    public func cancellablePATCH(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return cancellableStart(try OMGHTTPURLRQ.patch(url, json: json) as URLRequest)
     }
 
-    private func startCC(_ body: @autoclosure () throws -> URLRequest) -> CancellablePromise<(data: Data, response: URLResponse)> {
+    private func cancellableStart(_ body: @autoclosure () throws -> URLRequest) -> CancellablePromise<(data: Data, response: URLResponse)> {
         do {
             var request = try body()
 
@@ -314,7 +314,7 @@ extension URLSession {
                 request.setValue(OMGUserAgent(), forHTTPHeaderField: "User-Agent")
             }
 
-            return dataTaskCC(.promise, with: request)
+            return cancellableDataTask(.promise, with: request)
         } catch {
             return CancellablePromise(error: error)
         }

--- a/Sources/NSURLSession+OMG+Promise.swift
+++ b/Sources/NSURLSession+OMG+Promise.swift
@@ -168,3 +168,156 @@ extension URLSession {
         }
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension URLSession {
+    /**
+     Makes a cancellable **GET** request to the provided URL.
+
+         let p = URLSession.shared.GET("http://example.com", query: ["foo": "bar"])
+         p.then { data -> Void  in
+             //…
+         }
+         p.asImage().then { image -> Void  in
+            //…
+         }
+         p.asDictionary().then { json -> Void  in
+            //…
+         }
+
+     - Parameter url: The URL to request.
+     - Parameter query: The parameters to be encoded as the query string for the GET request.
+     - Returns: A cancellable promise that represents the GET request.
+     */
+    public func GETCC(_ url: String, query: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.get(url, query) as URLRequest)
+    }
+
+    /**
+     Makes a cancellable POST request to the provided URL passing form URL encoded
+     parameters.
+
+     Form URL-encoding is the standard way to POST on the Internet, so
+     probably this is what you want. If it doesn’t work, try the `+POST:JSON`
+     variant.
+
+         let url = "http://jsonplaceholder.typicode.com/posts"
+         let params = ["title": "foo", "body": "bar", "userId": 1]
+         URLSession.shared.POST(url, formData: params).asDictionary().then { json -> Void  in
+             //…
+         }
+
+     - Parameter url: The URL to request.
+     - Parameter formData: The parameters to be form URL-encoded and passed as the POST body.
+     - Returns: A cancellable promise that represents the POST request.
+     */
+    public func POSTCC(_ url: String, formData: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.post(url, formData) as URLRequest)
+    }
+
+    /**
+     Makes a cancellable POST request to the provided URL passing multipart form-data.
+
+        let formData = OMGMultipartFormData()
+        let imgData = Data(contentsOfFile: "image.png")
+        formData.addFile(imgdata, parameterName: "file1", filename: "myimage1.png", contentType: "image/png")
+
+        URLSession.shared.POST(url, multipartFormData: formData).then { data in
+            //…
+        }
+
+     - Parameter url: The URL to request.
+     - Parameter multipartFormData: The parameters to be multipart form-data encoded and passed as the POST body.
+     - Returns: A cancellable promise that represents the POST request.
+     - SeeAlso: [https://github.com/mxcl/OMGHTTPURLRQ](OMGHTTPURLRQ)
+     */
+    public func POSTCC(_ url: String, multipartFormData: OMGMultipartFormData) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.post(url, multipartFormData) as URLRequest)
+    }
+
+    /**
+     Makes a cancellable POST request to the provided URL passing JSON encoded
+     parameters.
+
+     Most web servers nowadays support POST with either JSON or form
+     URL-encoding. If in doubt try form URL-encoded parameters first.
+
+         let url = "http://jsonplaceholder.typicode.com/posts"
+         let params = ["title": "foo", "body": "bar", "userId": 1]
+         URLSession.shared.POST(url, json: params).asDictionary().then { json -> Void  in
+             //…
+         }
+
+     - Parameter url: The URL to request.
+     - Parameter json: The parameters to be JSON-encoded and passed as the POST body.
+     - Returns: A cancellable promise that represents the POST request.
+     */
+    public func POSTCC(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.post(url, json: json) as URLRequest)
+    }
+
+    /**
+     Makes a cancellable PUT request to the provided URL passing JSON encoded parameters.
+
+         let url = "http://jsonplaceholder.typicode.com/posts"
+         let params = ["title": "foo", "body": "bar", "userId": 1]
+         URLSession.shared.PUT(url, json: params).asDictionary().then { json -> Void  in
+             //…
+         }
+
+     - Parameter url: The URL to request.
+     - Parameter json: The parameters to be JSON-encoded and passed as the PUT body.
+     - Returns: A cancellable promise that represents the PUT request.
+     */
+    public func PUTCC(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.put(url, json: json) as URLRequest)
+    }
+
+    /**
+     Makes a cancellable DELETE request to the provided URL passing form URL-encoded
+     parameters.
+
+         let url = "http://jsonplaceholder.typicode.com/posts/1"
+         URLSession.shared.DELETE(url).then.asDictionary() { json -> Void in
+             //…
+         }
+
+     - Parameter url: The URL to request.
+     - Returns: A cancellable promise that represents the PUT request.
+     */
+    public func DELETECC(_ url: String) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.delete(url, nil) as URLRequest)
+    }
+
+    /**
+     Makes a cancellable PATCH request to the provided URL passing the provided JSON parameters.
+
+         let url = "http://jsonplaceholder.typicode.com/posts/1"
+         let params = ["foo": "bar"]
+         NSURLConnection.PATCH(url, json: params).asDictionary().then { json -> Void in
+             //…
+         }
+     - Parameter url: The URL to request.
+     - Parameter json: The JSON parameters to encode as the PATCH body.
+     - Returns: A cancellable promise that represents the PUT request.
+     */
+    public func PATCHCC(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        return startCC(try OMGHTTPURLRQ.patch(url, json: json) as URLRequest)
+    }
+
+    private func startCC(_ body: @autoclosure () throws -> URLRequest) -> CancellablePromise<(data: Data, response: URLResponse)> {
+        do {
+            var request = try body()
+
+            if request.value(forHTTPHeaderField: "User-Agent") == nil {
+                request.setValue(OMGUserAgent(), forHTTPHeaderField: "User-Agent")
+            }
+
+            return dataTaskCC(.promise, with: request)
+        } catch {
+            return CancellablePromise(error: error)
+        }
+    }
+}
+

--- a/Sources/NSURLSession+OMG+Promise.swift
+++ b/Sources/NSURLSession+OMG+Promise.swift
@@ -169,7 +169,7 @@ extension URLSession {
     }
 }
 
-//////////////////////////////////////////////////////////// Cancellation
+//////////////////////////////////////////////////////////// Cancellable wrappers
 
 extension URLSession {
     /**
@@ -191,7 +191,7 @@ extension URLSession {
      - Returns: A cancellable promise that represents the GET request.
      */
     public func cancellableGET(_ url: String, query: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.get(url, query) as URLRequest)
+        return cancellable(GET(url, query: query))
     }
 
     /**
@@ -213,7 +213,7 @@ extension URLSession {
      - Returns: A cancellable promise that represents the POST request.
      */
     public func cancellablePOST(_ url: String, formData: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.post(url, formData) as URLRequest)
+        return cancellable(POST(url, formData: formData))
     }
 
     /**
@@ -233,7 +233,7 @@ extension URLSession {
      - SeeAlso: [https://github.com/mxcl/OMGHTTPURLRQ](OMGHTTPURLRQ)
      */
     public func cancellablePOST(_ url: String, multipartFormData: OMGMultipartFormData) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.post(url, multipartFormData) as URLRequest)
+        return cancellable(POST(url, multipartFormData: multipartFormData))
     }
 
     /**
@@ -254,7 +254,7 @@ extension URLSession {
      - Returns: A cancellable promise that represents the POST request.
      */
     public func cancellablePOST(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.post(url, json: json) as URLRequest)
+        return cancellable(POST(url, json: json))
     }
 
     /**
@@ -271,7 +271,7 @@ extension URLSession {
      - Returns: A cancellable promise that represents the PUT request.
      */
     public func cancellablePUT(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.put(url, json: json) as URLRequest)
+        return cancellable(PUT(url, json: json))
     }
 
     /**
@@ -287,7 +287,7 @@ extension URLSession {
      - Returns: A cancellable promise that represents the PUT request.
      */
     public func cancellableDELETE(_ url: String) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.delete(url, nil) as URLRequest)
+        return cancellable(DELETE(url))
     }
 
     /**
@@ -303,21 +303,6 @@ extension URLSession {
      - Returns: A cancellable promise that represents the PUT request.
      */
     public func cancellablePATCH(_ url: String, json: [String: Any]? = nil) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        return cancellableStart(try OMGHTTPURLRQ.patch(url, json: json) as URLRequest)
-    }
-
-    private func cancellableStart(_ body: @autoclosure () throws -> URLRequest) -> CancellablePromise<(data: Data, response: URLResponse)> {
-        do {
-            var request = try body()
-
-            if request.value(forHTTPHeaderField: "User-Agent") == nil {
-                request.setValue(OMGUserAgent(), forHTTPHeaderField: "User-Agent")
-            }
-
-            return cancellableDataTask(.promise, with: request)
-        } catch {
-            return CancellablePromise(error: error)
-        }
+        return cancellable(PATCH(url, json: json))
     }
 }
-

--- a/Tests/TestNSURLSession.swift
+++ b/Tests/TestNSURLSession.swift
@@ -72,3 +72,81 @@ class NSURLSessionTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 }
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension NSURLSessionTests {
+    func testCancel1() {
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+
+        let ex = expectation(description: "")
+        URLSession.shared.GETCC("http://example.com").compactMap {
+            XCTFail()
+            try JSONSerialization.jsonObject(with: $0.data)
+        }.done {
+            XCTAssertEqual(json, $0 as? NSDictionary)
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }.cancel()
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancel2() {
+
+        // test that Promise<Data> chains thens
+        // this test because I don’t trust the Swift compiler
+
+        let dummy = ("fred" as NSString).data(using: String.Encoding.utf8.rawValue)!
+
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(data: dummy, statusCode: 200, headers: [:])
+        }
+
+        let ex = expectation(description: "")
+
+        afterCC(seconds: 0.1).then { () -> CancellablePromise<(data: Data, response: URLResponse)> in
+            let p = URLSession.shared.GETCC("http://example.com")
+            p.cancel()
+            return p
+        }.done {
+            XCTAssertEqual($0.data, dummy)
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancelSyntax() {
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+
+        OHHTTPStubs.stubRequests(passingTest: {
+            $0.url!.host == "example.com"
+        }, withStubResponse: { _ in
+            OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        })
+
+        let p = URLSession.shared.GETCC("http://example.com", query: [
+            "1": 1,
+            "2": 2
+        ])
+
+        let ex = expectation(description: "")
+        p.compactMap {
+            p.cancel()
+            try JSONSerialization.jsonObject(with: $0.data)
+        }.done {
+            XCTAssertEqual(json, $0 as? NSDictionary)
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Tests/TestNSURLSession.swift
+++ b/Tests/TestNSURLSession.swift
@@ -84,7 +84,7 @@ extension NSURLSessionTests {
         }
 
         let ex = expectation(description: "")
-        URLSession.shared.GETCC("http://example.com").compactMap {
+        URLSession.shared.cancellableGET("http://example.com").compactMap {
             XCTFail()
             try JSONSerialization.jsonObject(with: $0.data)
         }.done {
@@ -109,8 +109,8 @@ extension NSURLSessionTests {
 
         let ex = expectation(description: "")
 
-        afterCC(seconds: 0.1).then { () -> CancellablePromise<(data: Data, response: URLResponse)> in
-            let p = URLSession.shared.GETCC("http://example.com")
+        cancellable(after(seconds: 0.1)).then { () -> CancellablePromise<(data: Data, response: URLResponse)> in
+            let p = URLSession.shared.cancellableGET("http://example.com")
             p.cancel()
             return p
         }.done {
@@ -132,7 +132,7 @@ extension NSURLSessionTests {
             OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
         })
 
-        let p = URLSession.shared.GETCC("http://example.com", query: [
+        let p = URLSession.shared.cancellableGET("http://example.com", query: [
             "1": 1,
             "2": 2
         ])


### PR DESCRIPTION
These are the diffs for option 1 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 1 the new cancellation code is included with CorePromise.

There repositories involved with the pull request for option 1 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
