### PR TITLE
'Cancel' for PromiseKit option 2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,5 @@
 github "mxcl/PromiseKit" ~> 6.3
 github "mxcl/OMGHTTPURLRQ" ~> 3.2
 github "PromiseKit/Foundation" ~> 3.1
+#github "PromiseKit/Cancel" ~> 1.0
+github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,6 @@
 github "mxcl/PromiseKit" ~> 6.3
 github "mxcl/OMGHTTPURLRQ" ~> 3.2
-github "PromiseKit/Foundation" ~> 3.1
+#github "PromiseKit/Foundation" ~> 3.1
+github "dougzilla32/Foundation" "PMKCancel"
 #github "PromiseKit/Cancel" ~> 1.0
 github "dougzilla32/Cancel" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,5 @@
-github "mxcl/PromiseKit" ~> 6.3
+#github "mxcl/PromiseKit" ~> 6.3
+github "dougzilla32/PromiseKit" "PMKCancel"
 github "mxcl/OMGHTTPURLRQ" ~> 3.2
 #github "PromiseKit/Foundation" ~> 3.1
 github "dougzilla32/Foundation" "PMKCancel"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "PromiseKit/Foundation" "3.1.0"
+github "dougzilla32/Cancel" "1.0.0"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"
-github "mxcl/PromiseKit" "6.3.3"
+github "mxcl/PromiseKit" "6.3.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "PromiseKit/Foundation" "3.1.0"
 github "dougzilla32/Cancel" "1.0.0"
+github "dougzilla32/Foundation" "b4c2ea30a24a210f764490d4130be4c421afb8e6"
+github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"
-github "mxcl/PromiseKit" "6.3.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "dougzilla32/Cancel" "1.0.0"
-github "dougzilla32/Foundation" "b4c2ea30a24a210f764490d4130be4c421afb8e6"
+github "dougzilla32/Foundation" "1d0f84d4ae50db696feeb050f9dd9ebb90fd59be"
 github "dougzilla32/PromiseKit" "a0217bd7b69af68237dcdeee0197e63259b9d445"
 github "mxcl/OMGHTTPURLRQ" "3.2.5"

--- a/PMKOMGHTTPURLRQ.xcodeproj/project.pbxproj
+++ b/PMKOMGHTTPURLRQ.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 				OMGHTTPURLRQ,
 				OHHTTPStubs,
 				PMKFoundation,
+				PMKCancel,
 			);
 			name = "Embed Carthage Frameworks";
 			outputPaths = (

--- a/Tests/TestNSURLSession.swift
+++ b/Tests/TestNSURLSession.swift
@@ -1,3 +1,4 @@
+import PMKCancel
 import PMKOMGHTTPURLRQ
 import OHHTTPStubs
 import PromiseKit
@@ -70,5 +71,83 @@ class NSURLSessionTests: XCTestCase {
     
     override func tearDown() {
         OHHTTPStubs.removeAllStubs()
+    }
+}
+
+//////////////////////////////////////////////////////////// Cancellation
+
+extension NSURLSessionTests {
+    func testCancel1() {
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+
+        let ex = expectation(description: "")
+        URLSession.shared.GETCC("http://example.com").compactMap {
+            XCTFail()
+            try JSONSerialization.jsonObject(with: $0.data)
+        }.done {
+            XCTAssertEqual(json, $0 as? NSDictionary)
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }.cancel()
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancel2() {
+
+        // test that Promise<Data> chains thens
+        // this test because I don’t trust the Swift compiler
+
+        let dummy = ("fred" as NSString).data(using: String.Encoding.utf8.rawValue)!
+
+        OHHTTPStubs.stubRequests(passingTest: { $0.url!.host == "example.com" }) { _ in
+            return OHHTTPStubsResponse(data: dummy, statusCode: 200, headers: [:])
+        }
+
+        let ex = expectation(description: "")
+
+        afterCC(seconds: 0.1).then { () -> CancellablePromise<(data: Data, response: URLResponse)> in
+            let p = URLSession.shared.GETCC("http://example.com")
+            p.cancel()
+            return p
+        }.done {
+            XCTAssertEqual($0.data, dummy)
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCancelSyntax() {
+        let json: NSDictionary = ["key1": "value1", "key2": ["value2A", "value2B"]]
+
+        OHHTTPStubs.stubRequests(passingTest: {
+            $0.url!.host == "example.com"
+        }, withStubResponse: { _ in
+            OHHTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        })
+
+        let p = URLSession.shared.GETCC("http://example.com", query: [
+            "1": 1,
+            "2": 2
+        ])
+
+        let ex = expectation(description: "")
+        p.compactMap {
+            p.cancel()
+            try JSONSerialization.jsonObject(with: $0.data)
+        }.done {
+            XCTAssertEqual(json, $0 as? NSDictionary)
+            XCTFail()
+        }.catch(policy: .allErrors) {
+            $0.isCancelled ? ex.fulfill() : XCTFail()
+        }
+        waitForExpectations(timeout: 1)
     }
 }


### PR DESCRIPTION
These are the diffs for option 2 of [Proposal for PromiseKit cancellation support #896](https://github.com/mxcl/PromiseKit/issues/896).  With option 2 the new cancellation code goes in a new PromiseKit extension called PMKCancel.

The repository for the new PMKCancel extension is currently hosted at https://github.com/dougzilla32/Cancel, but would be moved to https://github.com/PromiseKit/Cancel if option 2 is accepted.

There repositories with pull requests for option 2 are:

Repositories  |
------------- |
[mxcl/PromiseKit](https://github.com/mxcl/PromiseKit) |
[PromiseKit/Alamofire-](https://github.com/PromiseKit/Alamofire-) |
[PromiseKit/Bolts](https://github.com/PromiseKit/Bolts) |
[dougzilla32/Cancel](https://github.com/dougzilla32/Cancel) |
[PromiseKit/CoreLocation](https://github.com/PromiseKit/CoreLocation) |
[PromiseKit/Foundation](https://github.com/PromiseKit/Foundation) |
[PromiseKit/MapKit](https://github.com/PromiseKit/MapKit) |
[PromiseKit/OMGHTTPURLRQ-](https://github.com/PromiseKit/OMGHTTPURLRQ-) |
[PromiseKit/StoreKit](https://github.com/PromiseKit/StoreKit) |
[PromiseKit/SystemConfiguration](https://github.com/PromiseKit/SystemConfiguration) |
[PromiseKit/UIKit](https://github.com/PromiseKit/UIKit) |
